### PR TITLE
fix(ui): 🐛 request token button permission for consenses network

### DIFF
--- a/web-app/components/Discord.tsx
+++ b/web-app/components/Discord.tsx
@@ -2,9 +2,11 @@ import { ConnectWalletButton } from '@/components/ConnectWalletButton'
 import { RequestTokenButton } from '@/components/RequestTokenButton'
 import { Web2SocialButton } from '@/components/Web2SocialButton'
 import { Contract } from '@/constants/contracts'
+import { NetworkOptions, useNetworkStore } from '@/store/useStore'
 import { Check, ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { RxDiscordLogo } from 'react-icons/rx'
+import { useNetwork } from 'wagmi'
 
 interface DiscordProps {
   isConnected: boolean
@@ -21,6 +23,8 @@ export const Discord: React.FC<DiscordProps> = ({
   address,
   setActiveTab
 }) => {
+  const { network } = useNetworkStore()
+  const { chain } = useNetwork()
   return (
     <div className='space-y-6'>
       <h3 className='text-xl font-semibold mb-4'>Request token via Discord</h3>
@@ -100,7 +104,14 @@ export const Discord: React.FC<DiscordProps> = ({
           <div className='flex-1 pt-1'>
             <div className='flex items-center justify-between'>
               <p className='font-medium'>Request token with the Faucet bot on Discord or here</p>
-              {contract && address && <RequestTokenButton contract={contract} address={address} />}
+
+              {chain && network === NetworkOptions.AUTO_EVM && address && isDiscordGuildMember && contract && (
+                <RequestTokenButton contract={contract} address={address} />
+              )}
+
+              {NetworkOptions.CONSENSUS === network && isDiscordGuildMember && address && (
+                <RequestTokenButton address={address} />
+              )}
             </div>
           </div>
         </li>

--- a/web-app/components/GitHub.tsx
+++ b/web-app/components/GitHub.tsx
@@ -4,8 +4,10 @@ import { ConnectWalletButton } from '@/components/ConnectWalletButton'
 import { RequestTokenButton } from '@/components/RequestTokenButton'
 import { Web2SocialButton } from '@/components/Web2SocialButton'
 import { Contract } from '@/constants/contracts'
+import { NetworkOptions, useNetworkStore } from '@/store/useStore'
 import { Check, ExternalLink, Github } from 'lucide-react'
 import Link from 'next/link'
+import { useNetwork } from 'wagmi'
 
 interface GitHubProps {
   isConnected: boolean
@@ -16,6 +18,8 @@ interface GitHubProps {
 }
 
 export const GitHub: React.FC<GitHubProps> = ({ isConnected, isGitHubFollower, contract, address, setActiveTab }) => {
+  const { network } = useNetworkStore()
+  const { chain } = useNetwork()
   return (
     <div className='space-y-6'>
       <h3 className='text-xl font-semibold mb-4'>Request token via GitHub</h3>
@@ -96,7 +100,14 @@ export const GitHub: React.FC<GitHubProps> = ({ isConnected, isGitHubFollower, c
           <div className='flex-1 pt-1'>
             <div className='flex items-center justify-between'>
               <p className='font-medium'>Request token</p>
-              {contract && address && <RequestTokenButton contract={contract} address={address} />}
+
+              {chain && network === NetworkOptions.AUTO_EVM && isGitHubFollower && address && contract && (
+                <RequestTokenButton contract={contract} address={address} />
+              )}
+
+              {NetworkOptions.CONSENSUS === network && isGitHubFollower && address && (
+                <RequestTokenButton address={address} />
+              )}
             </div>
           </div>
         </li>

--- a/web-app/components/RequestTokenButton.tsx
+++ b/web-app/components/RequestTokenButton.tsx
@@ -12,7 +12,7 @@ import { toast } from 'react-toastify'
 import { useContractReads, useNetwork } from 'wagmi'
 
 interface RequestTokenButtonProps {
-  contract: Contract
+  contract?: Contract
   address: string
 }
 

--- a/web-app/components/TokenCard.tsx
+++ b/web-app/components/TokenCard.tsx
@@ -21,7 +21,16 @@ export const TokenCard: React.FC = () => {
   const { network } = useNetworkStore()
   const { actingAccount } = useWallet()
 
-  const contract = useMemo(() => chain && contracts.find((c) => c.name === 'Faucet' && c.chainId === chain.id), [chain])
+  const contract = useMemo(() => {
+    if (chain && network === NetworkOptions.AUTO_EVM) {
+      return contracts.find((c) => c.name === 'Faucet' && c.chainId === chain.id)
+    }
+    if (network === NetworkOptions.CONSENSUS) {
+      return contracts.find((c) => c.name === 'ConsensusFaucet' && c.chainId === -1)
+    }
+    return undefined
+  }, [chain, network])
+
   const isGitHubFollower = useMemo(
     () => !!(session && session.user != null && session.user.isGitHubFollower),
     [session]

--- a/web-app/components/TokenCard.tsx
+++ b/web-app/components/TokenCard.tsx
@@ -14,19 +14,15 @@ import { useAccount, useNetwork } from 'wagmi'
 
 export const TokenCard: React.FC = () => {
   const [clientSide, setClientSide] = useState(false)
-  const [activeTab, setActiveTab] = useState('github')
   const { isConnected, address } = useAccount()
   const { chain } = useNetwork()
   const { data: session } = useSession()
-  const { network } = useNetworkStore()
+  const { network, activeTab, setActiveTab } = useNetworkStore()
   const { actingAccount } = useWallet()
 
   const contract = useMemo(() => {
     if (chain && network === NetworkOptions.AUTO_EVM) {
       return contracts.find((c) => c.name === 'Faucet' && c.chainId === chain.id)
-    }
-    if (network === NetworkOptions.CONSENSUS) {
-      return contracts.find((c) => c.name === 'ConsensusFaucet' && c.chainId === -1)
     }
     return undefined
   }, [chain, network])

--- a/web-app/constants/contracts.ts
+++ b/web-app/constants/contracts.ts
@@ -74,11 +74,5 @@ export const contracts: Contract[] = [
     name: 'Faucet',
     address: `0x2296dbb90C714c1355Ff9cbcB70D5AB29060b454`,
     abi: FAUCET
-  },
-  {
-    chainId: -1,
-    name: 'ConsensusFaucet',
-    address: `0x2296dbb90C714c1355Ff9cbcB70D5AB29060b454`,
-    abi: FAUCET
   }
 ]

--- a/web-app/constants/contracts.ts
+++ b/web-app/constants/contracts.ts
@@ -74,5 +74,11 @@ export const contracts: Contract[] = [
     name: 'Faucet',
     address: `0x2296dbb90C714c1355Ff9cbcB70D5AB29060b454`,
     abi: FAUCET
+  },
+  {
+    chainId: -1,
+    name: 'ConsensusFaucet',
+    address: `0x2296dbb90C714c1355Ff9cbcB70D5AB29060b454`,
+    abi: FAUCET
   }
 ]

--- a/web-app/store/useStore.ts
+++ b/web-app/store/useStore.ts
@@ -14,6 +14,8 @@ interface NetworkState {
   networks: Network[]
   version: number
   setNetworks: (networks: Network[]) => void
+  activeTab: string
+  setActiveTab: (tab: string) => void
 }
 
 export const useNetworkStore = create<NetworkState>()(
@@ -23,7 +25,9 @@ export const useNetworkStore = create<NetworkState>()(
       setNetwork: (network: NetworkOptions) => set({ network }),
       networks: networks,
       version: 1,
-      setNetworks: (networks: Network[]) => set({ networks })
+      setNetworks: (networks: Network[]) => set({ networks }),
+      activeTab: 'github',
+      setActiveTab: (tab: string) => set({ activeTab: tab })
     }),
     {
       name: 'network-storage',


### PR DESCRIPTION
The request token button failed to display when the server was directly connected with the `Consensus` network, so I added a different permission.